### PR TITLE
Rerender feedstock to enable builds for Mac and Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,11 +8,18 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_python3.6.____cpython:
+        CONFIG: linux_64_python3.6.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+      linux_64_python3.7.____cpython:
+        CONFIG: linux_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_64_python3.8.____cpython:
+        CONFIG: linux_64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,34 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-10.15
+  strategy:
+    matrix:
+      osx_64_python3.6.____cpython:
+        CONFIG: osx_64_python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.7.____cpython:
+        CONFIG: osx_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_python3.8.____cpython:
+        CONFIG: osx_64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,0 +1,116 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: win
+  pool:
+    vmImage: vs2017-win2016
+  strategy:
+    matrix:
+      win_64_python3.6.____cpython:
+        CONFIG: win_64_python3.6.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.7.____cpython:
+        CONFIG: win_64_python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_python3.8.____cpython:
+        CONFIG: win_64_python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables:
+    CONDA_BLD_PATH: D:\\bld\\
+
+  steps:
+    - script: |
+        choco install vcpython27 -fdv -y --debug
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Install vcpython27.msi (if needed)
+
+    # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    # - script: rmdir C:\cygwin /s /q
+    #   continueOnError: true
+
+    - powershell: |
+        Set-PSDebug -Trace 1
+
+        $batchcontent = @"
+        ECHO ON
+        SET vcpython=C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0
+
+        DIR "%vcpython%"
+
+        CALL "%vcpython%\vcvarsall.bat" %*
+        "@
+
+        $batchDir = "C:\Program Files (x86)\Common Files\Microsoft\Visual C++ for Python\9.0\VC"
+        $batchPath = "$batchDir" + "\vcvarsall.bat"
+        New-Item -Path $batchPath -ItemType "file" -Force
+
+        Set-Content -Value $batchcontent -Path $batchPath
+
+        Get-ChildItem -Path $batchDir
+
+        Get-ChildItem -Path ($batchDir + '\..')
+
+      condition: contains(variables['CONFIG'], 'vs2008')
+      displayName: Patch vs2008 (if needed)
+
+    - task: CondaEnvironment@1
+      inputs:
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
+        installOptions: "-c conda-forge"
+        updateConda: true
+      displayName: Install conda-build and activate environment
+
+    - script: set PYTHONUNBUFFERED=1
+      displayName: Set PYTHONUNBUFFERED
+
+    # Configure the VM
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
+
+    # Configure the VM.
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
+      displayName: conda-forge build setup
+    
+
+    # Special cased version setting some more things!
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe (vs2008)
+      env:
+        VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin"
+        PYTHONUNBUFFERED: 1
+      condition: contains(variables['CONFIG'], 'vs2008')
+
+    - script: |
+        call activate base
+        conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml
+      displayName: Build recipe
+      env:
+        PYTHONUNBUFFERED: 1
+      condition: not(contains(variables['CONFIG'], 'vs2008'))
+    - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
+      displayName: Validate Recipe Outputs
+
+    - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        call activate base
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+      displayName: Upload package
+      env:
+        BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+        FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+        STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -1,0 +1,14 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+docker_image:
+- condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -4,3 +4,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-64

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -1,0 +1,16 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- osx-64

--- a/.ci_support/win_64_python3.6.____cpython.yaml
+++ b/.ci_support/win_64_python3.6.____cpython.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.6.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -1,0 +1,12 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- win-64

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -x
+
+echo -e "\n\nInstalling a fresh version of Miniforge."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:install_miniforge\\r'
+fi
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
+MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+bash $MINIFORGE_FILE -b
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:install_miniforge\\r'
+fi
+
+echo -e "\n\nConfiguring conda."
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:start:configure_conda\\r'
+fi
+
+source ${HOME}/miniforge3/etc/profile.d/conda.sh
+conda activate base
+
+echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+
+echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+/usr/bin/sudo mangle_homebrew
+/usr/bin/sudo -k
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+if [[ ${CI} == "travis" ]]; then
+  echo -en 'travis_fold:end:configure_conda\\r'
+fi
+
+set -e
+
+echo -e "\n\nMaking the build clobber file and running the build."
+make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+  echo -e "\n\nUploading the packages."
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+fi

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Home: https://nox.thea.codes
 
 Package license: Apache-2.0
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/nox-feedstock/blob/master/LICENSE.txt)
 
 Summary: Flexible test automation for Python
+
+Development: https://github.com/theacodes/nox
+
+Documentation: https://nox.thea.codes
 
 nox is a command-line tool that automates testing in multiple Python
 environments, similar to Tox. Unlike Tox, Nox uses a standard Python
@@ -18,11 +22,86 @@ Current build status
 ====================
 
 
-<table><tr><td>All platforms:</td>
+<table>
+    
+  <tr>
+    <td>Azure</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master">
-      </a>
+      <details>
+        <summary>
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master">
+          </a>
+        </summary>
+        <table>
+          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
+          <tbody><tr>
+              <td>linux_64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=win&configuration=win_64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5053&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/nox-feedstock?branchName=master&jobName=win&configuration=win_64_python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </details>
     </td>
   </tr>
 </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,3 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: efa5adcf1134012f96bcd0a496ccebd4c9e9da53a831888a2a779462440eebcf
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
   entry_points:
     - nox = nox.__main__:main


### PR DESCRIPTION
It seems that after removing `noarch` in #7 the feedstock wasn't rerendered to enable builds on all platforms (noarch is built only on linux). This uses the latest conda-smithy to render. If we're lucky, it might resolve #10 #8 #9 since virtualenv and tox have already updated.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
