### PR TITLE
Remove py dependency from recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - argcomplete >=1.9.4,<2.0
     - colorlog >=2.6.1,<7.0.0
     - packaging >=20.9
-    - py >=1.4.0,<2.0.0
     - typing_extensions >=3.7.4  # [py<=38]
     - virtualenv >=14.0.0
     - importlib_metadata  # [py<=38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e21c31de0711d1274ca585a2c5fde36b1aa962005ba8e9322bf5eeed16dcd684
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
   entry_points:
     - nox = nox.__main__:main


### PR DESCRIPTION
py is no longer needed by nox code according to:
https://github.com/wntrblm/nox/blob/main/CHANGELOG.md https://github.com/wntrblm/nox/pull/647

Not installing py in the first place is a good way avoid this vulnerability:
https://github.com/pytest-dev/py/issues/287

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
